### PR TITLE
[RTM] Implement display_order handling for form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Contao Mailchimp
 ==========================
 
-This extension provides subscribe and unsubscribe forms for easy integration in Contao.  
+This extension provides subscribe and unsubscribe forms for easy integration in Contao.
 
 [![Author](http://img.shields.io/badge/author-@1upgmbh-blue.svg?style=flat-square)](https://twitter.com/1upgmbh)
 [![Software License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
@@ -9,4 +9,4 @@ This extension provides subscribe and unsubscribe forms for easy integration in 
 
 --
 
-The fields that will be shown are managed through MailChimp's [`List fields and *|MERGE|* tags`](http://kb.mailchimp.com/lists/managing-subscribers/set-default-merge-values-for-a-list).
+The fields that will be shown are managed through MailChimp's [`List fields and *|MERGE|* tags`](http://kb.mailchimp.com/lists/managing-subscribers/set-default-merge-values-for-a-list). You may also change the order of this fields: In MailChimp, go to Signup forms > General forms > Signup Form and rearrange the fields via drag'n'drop. You then have to import the new field order into Contao, by simply re-saving the MailChimp list in the back end. 

--- a/src/MailChimp/Model/MailChimpModel.php
+++ b/src/MailChimp/Model/MailChimpModel.php
@@ -46,6 +46,7 @@ class MailChimpModel extends Model
                     'tag' => $rawField->tag,
                     'name' => $rawField->name,
                     'type' => $rawField->type,
+                    'display_order' => $rawField->display_order,
                     'required' => !!$rawField->required,
                     'options' => $rawField->options,
                     'public' => $rawField->public,

--- a/src/MailChimp/Model/MailChimpModel.php
+++ b/src/MailChimp/Model/MailChimpModel.php
@@ -46,7 +46,7 @@ class MailChimpModel extends Model
                     'tag' => $rawField->tag,
                     'name' => $rawField->name,
                     'type' => $rawField->type,
-                    'display_order' => $rawField->display_order,
+                    'displayOrder' => $rawField->display_order,
                     'required' => !!$rawField->required,
                     'options' => $rawField->options,
                     'public' => $rawField->public,

--- a/src/MailChimp/Module/ModuleSubscribe.php
+++ b/src/MailChimp/Module/ModuleSubscribe.php
@@ -49,9 +49,9 @@ class ModuleSubscribe extends Module
 
         $fields = json_decode($this->objMailChimp->fields);
 
-        // sort fields by display_order ASC
+        // sort fields by displayOrder ASC
         usort($fields, function($a, $b) {
-            return ($a->display_order > $b->display_order) ? 1 : -1;
+            return ($a->displayOrder > $b->displayOrder) ? 1 : -1;
         });
 
         $fields = $this->insertEmailField($fields);
@@ -119,32 +119,32 @@ class ModuleSubscribe extends Module
             'tag' => 'EMAIL',
             'name' => $GLOBALS['TL_LANG']['tl_module']['mailchimp']['labelEmail'],
             'type' => 'text',
-            'display_order' => -1,
+            'displayOrder' => -1,
             'required' => true,
             'public' => true,
         ];
 
         // if first field is displayed second, insert email field before
-        if ($fields[0]->display_order === 2) {
-            $email->display_order = 1;
+        if (2 === $fields[0]->displayOrder) {
+            $email->displayOrder = 1;
         } else {
             // check if display order is consecutive
-            $index = $fields[0]->display_order;
+            $index = $fields[0]->displayOrder;
             foreach ($fields as $field) {
                 // if one display slot is missing, the email field goes here
-                if ($field->display_order === ($index + 1)) {
-                    $email->display_order = $index;
+                if (($index + 1) === $field->displayOrder) {
+                    $email->displayOrder = $index;
                     break;
                 }
                 $index++;
             }
             // otherwise, append email field
-            if ($email->display_order === -1) {
-                $email->display_order = (count($fields) + 1);
+            if (-1 === $email->displayOrder) {
+                $email->displayOrder = (count($fields) + 1);
             }
         }
 
-        array_splice($fields, ($email->display_order - 1), 0, [$email]);
+        array_splice($fields, ($email->displayOrder - 1), 0, [$email]);
         return $fields;
     }
 

--- a/src/MailChimp/Module/ModuleSubscribe.php
+++ b/src/MailChimp/Module/ModuleSubscribe.php
@@ -182,7 +182,6 @@ class ModuleSubscribe extends Module
                 ]);
 
                 break;
-            case 'email':
             case 'text':
             case 'address':
             case 'date':


### PR DESCRIPTION
Hi there, 

as discussed in #6 , the implementation should respect the order of the form fields, that can be changed in the MailChimp interface. This PR takes care of this.

One known issue is, that since the email field itself is still not included in the API response, the chosen email field label in MailChimp is obviously not available in Contao. It still has to be changed through the language array, as it was prior to this PR. 

Let me know what you all think :)

Cheers!
