### PR TITLE
fix required dropdown and radio fields

### DIFF
--- a/src/Module/ModuleSubscribe.php
+++ b/src/Module/ModuleSubscribe.php
@@ -287,7 +287,7 @@ class ModuleSubscribe extends Module
                     'inputType' => $inputType,
                     'options' => $field->options->choices,
                     'eval' => [
-                        'required' => $field->required,
+                        'mandatory' => $field->required,
                     ],
                     'default' => $field->default,
                 ]);
@@ -306,7 +306,7 @@ class ModuleSubscribe extends Module
                     'inputType' => $inputType,
                     'options' => $field->options->choices,
                     'eval' => [
-                        'required' => $field->required,
+                        'mandatory' => $field->required,
                     ],
                     'default' => $field->default,
                 ]);


### PR DESCRIPTION
Currently dropdown and radio fields are not set as required, even if you have them set as required in MailChimp. This is because `required` was used for the DCA config instead of `mandatory`.