### PR TITLE
[RTM] add hook so you can modify the form

### DIFF
--- a/src/Event/ModifyFormEvent.php
+++ b/src/Event/ModifyFormEvent.php
@@ -18,7 +18,7 @@ class ModifyFormEvent extends Event
     public const SUBSCRIBE = 'contao_mailchimp.modify_subscribe_form';
 
     /**
-     * The contao_mailchimp.modify_unsubscribe_form event is triggered when the subscribe form is finished creating the form object
+     * The contao_mailchimp.modify_unsubscribe_form event is triggered when the unsubscribe form is finished creating the form object
      *
      * @var string
      */

--- a/src/Event/ModifyFormEvent.php
+++ b/src/Event/ModifyFormEvent.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneup\Contao\MailChimpBundle\Event;
+
+use Contao\Module;
+use Haste\Form\Form;
+use Symfony\Component\EventDispatcher\Event;
+
+class ModifyFormEvent extends Event
+{
+    /**
+     * The contao_mailchimp.modify_subscribe_form event is triggered when the subscribe form is finished creating the form object
+     *
+     * @var string
+     */
+    public const SUBSCRIBE = 'contao_mailchimp.modify_subscribe_form';
+
+    /**
+     * The contao_mailchimp.modify_unsubscribe_form event is triggered when the subscribe form is finished creating the form object
+     *
+     * @var string
+     */
+    public const UNSUBSCRIBE = 'contao_mailchimp.modify_unsubscribe_form';
+
+    /**
+     * @var Form
+     */
+    private $form;
+
+    /**
+     * @var Module
+     */
+    private $module;
+
+    /**
+     * @param Form $form
+     */
+    public function __construct(Form $form, Module $module)
+    {
+        $this->form = $form;
+        $this->module = $module;
+    }
+
+    /**
+     * @return Form
+     */
+    public function getForm(): Form
+    {
+        return $this->form;
+    }
+
+    /**
+     * @return ModifyFormEvent
+     */
+    public function setForm(Form $form): ModifyFormEvent
+    {
+        $this->form = $form;
+        return $this;
+    }
+
+    /**
+     * @return Module
+     */
+    public function getModule(): Module
+    {
+        return $this->module;
+    }
+
+    /**
+     * @return ModifyFormEvent
+     */
+    public function setModule(Module $module): ModifyFormEvent
+    {
+        $this->module = $module;
+        return $this;
+    }
+}

--- a/src/Event/ModifyFormEvent.php
+++ b/src/Event/ModifyFormEvent.php
@@ -52,28 +52,10 @@ class ModifyFormEvent extends Event
     }
 
     /**
-     * @return ModifyFormEvent
-     */
-    public function setForm(Form $form): ModifyFormEvent
-    {
-        $this->form = $form;
-        return $this;
-    }
-
-    /**
      * @return Module
      */
     public function getModule(): Module
     {
         return $this->module;
-    }
-
-    /**
-     * @return ModifyFormEvent
-     */
-    public function setModule(Module $module): ModifyFormEvent
-    {
-        $this->module = $module;
-        return $this;
     }
 }

--- a/src/Module/ModuleSubscribe.php
+++ b/src/Module/ModuleSubscribe.php
@@ -115,10 +115,8 @@ class ModuleSubscribe extends Module
         $objForm->addContaoHiddenFields();
 
         // HOOK: alter form
-        if (isset($GLOBALS['TL_HOOKS']['modifyMailChimpForm']) && \is_array($GLOBALS['TL_HOOKS']['modifyMailChimpForm']))
-        {
-            foreach ($GLOBALS['TL_HOOKS']['modifyMailChimpForm'] as $callback)
-            {
+        if (isset($GLOBALS['TL_HOOKS']['modifyMailChimpForm']) && \is_array($GLOBALS['TL_HOOKS']['modifyMailChimpForm'])) {
+            foreach ($GLOBALS['TL_HOOKS']['modifyMailChimpForm'] as $callback) {
                 $this->import($callback[0]);
                 $this->{$callback[0]}->{$callback[1]}($objForm, $this);
             }

--- a/src/Module/ModuleSubscribe.php
+++ b/src/Module/ModuleSubscribe.php
@@ -114,6 +114,16 @@ class ModuleSubscribe extends Module
 
         $objForm->addContaoHiddenFields();
 
+        // HOOK: alter form
+        if (isset($GLOBALS['TL_HOOKS']['modifyMailChimpForm']) && \is_array($GLOBALS['TL_HOOKS']['modifyMailChimpForm']))
+        {
+            foreach ($GLOBALS['TL_HOOKS']['modifyMailChimpForm'] as $callback)
+            {
+                $this->import($callback[0]);
+                $this->{$callback[0]}->{$callback[1]}($objForm, $this);
+            }
+        }
+
         $this->Template->error = false;
 
         if ($objForm->validate()) {

--- a/src/Module/ModuleSubscribe.php
+++ b/src/Module/ModuleSubscribe.php
@@ -11,6 +11,7 @@ use Contao\Input;
 use Contao\Module;
 use Contao\System;
 use Haste\Form\Form;
+use Oneup\Contao\MailChimpBundle\Event\ModifyFormEvent;
 use Oneup\Contao\MailChimpBundle\Model\MailChimpModel;
 use Oneup\MailChimp\Client;
 use Patchwork\Utf8;
@@ -114,13 +115,11 @@ class ModuleSubscribe extends Module
 
         $objForm->addContaoHiddenFields();
 
-        // HOOK: alter form
-        if (isset($GLOBALS['TL_HOOKS']['modifyMailChimpForm']) && \is_array($GLOBALS['TL_HOOKS']['modifyMailChimpForm'])) {
-            foreach ($GLOBALS['TL_HOOKS']['modifyMailChimpForm'] as $callback) {
-                $this->import($callback[0]);
-                $this->{$callback[0]}->{$callback[1]}($objForm, $this);
-            }
-        }
+        // event: modify form
+        System::getContainer()->get('event_dispatcher')->dispatch(
+            ModifyFormEvent::SUBSCRIBE, 
+            new ModifyFormEvent($objForm, $this)
+        );
 
         $this->Template->error = false;
 

--- a/src/Module/ModuleUnsubscribe.php
+++ b/src/Module/ModuleUnsubscribe.php
@@ -72,6 +72,12 @@ class ModuleUnsubscribe extends Module
 
         $objForm->addContaoHiddenFields();
 
+        // event: modify form
+        System::getContainer()->get('event_dispatcher')->dispatch(
+            ModifyFormEvent::UNSUBSCRIBE, 
+            new ModifyFormEvent($objForm, $this)
+        );
+
         $this->Template->error = false;
 
         if ($objForm->validate()) {


### PR DESCRIPTION
This would allow you to modify the form to your needs. Example:
```php
public function modifyMailChimpForm(\Haste\Form\Form $objForm, \Oneup\Contao\MailChimpBundle\Module\ModuleSubscribe $objModule)
{
    $objForm->removeFormField('submit');

    $objForm->addFormField('mandatory', [
        'inputType' => 'explanation',
        'eval' => ['text' => '<p>Some additional explanation before the submit button.</p>']
    ]);

    $objForm->addFormField('submit', [
        'label' => $GLOBALS['TL_LANG']['tl_module']['mailchimp']['labelSubmit'],
        'inputType' => 'submit',
    ]);
}
```
However, what does not work is stuff like this:
```php
$objForm->getWidget('SALUTATION')->label = 'Foo';
```
Though I do not really get why.