### PR TITLE
[RTM] allow selection of which interest groups should be mandatory

### DIFF
--- a/src/EventListener/DcaListener.php
+++ b/src/EventListener/DcaListener.php
@@ -97,4 +97,28 @@ class DcaListener
             Controller::redirect('contao/main.php?act=error');
         }
     }
+
+    public function onLoadInterests($dc)
+    {
+        if ($dc && $dc->activeRecord && $dc->activeRecord->mailchimpList) {
+
+            if (null !== ($record = MailChimpModel::findByPk($dc->activeRecord->mailchimpList))) {
+
+                if (!empty($record->groups) && ($groups = json_decode($record->groups))) {
+
+                    $options = [];
+
+                    foreach ($groups as $group) {
+                        if ('hidden' !== $group->type) {
+                            $options[$group->id] = $group->title;
+                        }
+                    }
+
+                    return $options;
+                }
+            }
+        }
+
+        return [];
+    }
 }

--- a/src/Module/ModuleSubscribe.php
+++ b/src/Module/ModuleSubscribe.php
@@ -390,7 +390,8 @@ class ModuleSubscribe extends Module
 
         $inputType = str_replace(['checkboxes', 'dropdown'], ['checkbox', 'select'], $category->type);
         $options = [];
-        $eval = ['mandatory' => (bool) $this->mailchimpMandatoryInterests];
+        $mandatoryInterests = \deserialize($this->mailchimpMandatoryInterests, true);
+        $eval = ['mandatory' => \in_array($category->id, $mandatoryInterests)];
 
         foreach ($interests as $interest) {
             $options[$interest->id] = $interest->name;

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -28,6 +28,8 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['mailchimpList'] = [
     'foreignKey' => 'tl_mailchimp.listName',
     'eval' => [
         'mandatory' => true,
+        'submitOnChange' => true,
+        'includeBlankOption' => true,
     ],
     'sql' => "varchar(128) NOT NULL default ''",
 ];
@@ -66,9 +68,11 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['mailchimpShowPlaceholder'] = [
 $GLOBALS['TL_DCA']['tl_module']['fields']['mailchimpMandatoryInterests'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_module']['mailchimpMandatoryInterests'],
     'inputType' => 'checkbox',
+    'options_callback' => [Oneup\Contao\MailChimpBundle\EventListener\DcaListener::class, 'onLoadInterests'],
     'eval' => [
         'mandatory' => false,
         'isBoolean' => true,
+        'multiple' => true,
     ],
-    'sql' => "varchar(1) NOT NULL default ''",
+    'sql' => "blob NULL",
 ];


### PR DESCRIPTION
* `mailchimpMandatoryInterests` now has an `options_callback` that loads the interest groups from the MailChimp list.
* In order to ensure that the interest groups are loaded, I added `'submitOnChange' => true` and `'includeBlankOption' => true` to `eval` of `mailchimpList`.

_Careful:_ this changes the usage of the `mailchimpMandatoryInterests` field. While previously it was a simple boolean, now it contains a blob of serialized groups that should be mandatory. Technically this would need to be released as a major version - though may be you can release it as a feature version, since `mailchimpMandatoryInterests` was only recently introduced...