### PR TITLE
Implement form subscriptions

### DIFF
--- a/src/EventListener/FormSubscriptionListener.php
+++ b/src/EventListener/FormSubscriptionListener.php
@@ -93,7 +93,7 @@ class FormSubscriptionListener
         $mergeTags = StringUtil::deserialize($value, true);
 
         foreach ($mergeTags as $mergeTag) {
-            if ('EMAIL' === $mergeTag['key'] ?? null && !empty($mergeTag['value'])) {
+            if ('EMAIL' === ($mergeTag['key'] ?? null) && !empty($mergeTag['value'])) {
                 return $value;
             }
         }

--- a/src/EventListener/FormSubscriptionListener.php
+++ b/src/EventListener/FormSubscriptionListener.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneup\Contao\MailChimpBundle\EventListener;
+
+use Contao\CoreBundle\Monolog\ContaoContext;
+use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\ServiceAnnotation\Hook;
+use Contao\DataContainer;
+use Contao\Form;
+use Contao\StringUtil;
+use Oneup\Contao\MailChimpBundle\Model\MailChimpModel;
+use Oneup\MailChimp\Client;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * This service handles all necessary callbacks of the Mailchimp subscription functionality for Contao forms.
+ */
+class FormSubscriptionListener
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(LoggerInterface $logger, TranslatorInterface $translator)
+    {
+        $this->logger = $logger;
+        $this->translator = $translator;
+    }
+
+    /**
+     * Returns the list of group categories from the Mailchimp API 
+     * for the currently selected Mailchimp list.
+     * 
+     * @Callback(table="tl_form", target="fields.mailchimpGroups.options")
+     */
+    public function onMailchimpGroupsOptionsCallback(DataContainer $dc): array
+    {
+        $options = [];
+
+        if (empty($dc->activeRecord->mailchimpList)) {
+            return $options;
+        }
+
+        $model = MailChimpModel::findByPk($dc->activeRecord->mailchimpList);
+
+        if (null === $model) {
+            return $options;
+        }
+
+        $api = new Client($model->listApiKey);
+
+        $listGroupCategories = $api->getListGroupCategories($model->listId);
+
+        if (empty($listGroupCategories->categories)) {
+            return $options;
+        }
+
+        foreach ($listGroupCategories->categories as $category) {
+            $listGroup = $api->getListGroup($category->list_id, $category->id);
+
+            if (empty($listGroup->interests)) {
+                continue;
+            }
+
+            foreach ($listGroup->interests as $interest) {
+                $options[$category->title][$interest->id] = $interest->name;
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Checks whether the merge tags have at least "EMAIL".
+     * 
+     * @Callback(table="tl_form", target="fields.mailchimpMergeTags.save")
+     * 
+     * @param mixed $value
+     * @return mixed
+     */
+    public function onMailchimpMergeTagsSaveCallback($value, DataContainer $dc)
+    {
+        $mergeTags = StringUtil::deserialize($value, true);
+
+        foreach ($mergeTags as $mergeTag) {
+            if ('EMAIL' === $mergeTag['key'] ?? null && !empty($mergeTag['value'])) {
+                return $value;
+            }
+        }
+
+        throw new \Exception($this->translator->trans('ERR.mailchimpMergeTagsEmailMissing', [], 'contao_default'));
+    }
+
+    /**
+     * Subscribes to a Mailchimp list if enabled.
+     * 
+     * @Hook("processFormData")
+     */
+    public function onProcessFormData(array $submittedData, array $formData, ?array $files, array $labels, Form $form): void
+    {
+        // Check if Mailchimp subscriptions are enabled for this form
+        if (!$form->enableMailchimp || empty($form->mailchimpList)) {
+            return;
+        }
+
+        // Check if subscription process is confirmed
+        if (!empty($form->mailchimpConfirmField) && empty($submittedData[$form->mailchimpConfirmField])) {
+            return;
+        }
+
+        $model = MailChimpModel::findByPk($form->mailchimpList);
+
+        if (null === $model) {
+            return;
+        }
+
+        // Set interest groups
+        $interests = [];
+        foreach (StringUtil::deserialize($form->mailchimpGroups, true) as $group) {
+            $interests[$group] = true;
+        }
+
+        // Extract merge vars
+        $mergeVars = [];
+        foreach (StringUtil::deserialize($form->mailchimpMergeTags, true) as $mergeTag) {
+            $mergeVars[$mergeTag['key']] = $submittedData[$mergeTag['value']] ?? null;
+        }
+
+        // Check if we have an email address
+        if (empty($mergeVars['EMAIL'])) {
+            return;
+        }
+
+        $api = new Client($model->listApiKey);
+        $email = $mergeVars['EMAIL'];
+        $result = $api->subscribeToList($model->listId, $email, $mergeVars, (bool) $form->mailchimpOptIn, $interests);
+
+        if ($result) {
+            $this->logger->log(LogLevel::INFO, sprintf('Successfully subscribed "%s" to Mailchimp list "%s".', $email, $model->listName), ['contao' => new ContaoContext(__METHOD__, TL_GENERAL)]);
+        } else {
+            $this->logger->log(LogLevel::INFO, sprintf('Could not subscribe "%s" to Mailchimp list "%s".', $email, $model->listName), ['contao' => new ContaoContext(__METHOD__, TL_ERROR)]);
+        }
+    }
+}

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -2,3 +2,9 @@ services:
     oneup_contao_mailchimp.listener.dca:
         class: Oneup\Contao\MailChimpBundle\EventListener\DcaListener
         public: true
+
+    Oneup\Contao\MailChimpBundle\EventListener\FormSubscriptionListener:
+        autoconfigure: true
+        arguments:
+            - '@logger'
+            - '@translator'

--- a/src/Resources/contao/dca/tl_form.php
+++ b/src/Resources/contao/dca/tl_form.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
+$GLOBALS['TL_DCA']['tl_form']['fields']['enableMailchimp'] = [
+    'exclude' => true,
+    'inputType' => 'checkbox',
+    'eval' => ['tl_class' => 'clr', 'submitOnChange' => true],
+    'sql' => ['type' => 'boolean', 'default' => false],
+];
+
+$GLOBALS['TL_DCA']['tl_form']['fields']['mailchimpList'] = [
+    'label' => &$GLOBALS['TL_LANG']['tl_module']['mailchimpList'],
+    'exclude' => true,
+    'inputType' => 'select',
+    'foreignKey' => 'tl_mailchimp.listName',
+    'eval' => [
+        'mandatory' => true,
+        'includeBlankOption' => true,
+        'tl_class' => 'w50',
+        'submitOnChange' => true,
+    ],
+    'sql' => ['type' => 'integer', 'unsigned' => true, 'default' => 0],
+];
+
+$GLOBALS['TL_DCA']['tl_form']['fields']['mailchimpGroups'] = [
+    'inputType' => 'checkbox',
+    'eval' => [
+        'tl_class' => 'clr', 
+        'includeBlankOption' => true, 
+        'multiple' => true,
+    ],
+    'sql' => ['type' => 'blob', 'notnull' => false],
+];
+
+$GLOBALS['TL_DCA']['tl_form']['fields']['mailchimpMergeTags'] = [
+    'inputType' => 'keyValueWizard',
+    'eval' => ['tl_class' => 'clr'],
+    'sql' => ['type' => 'blob', 'notnull' => false],
+];
+
+$GLOBALS['TL_DCA']['tl_form']['fields']['mailchimpConfirmField'] = [
+    'inputType' => 'text',
+    'eval' => ['tl_class' => 'w50', 'maxlength' => 128],
+    'sql' => ['type' => 'string', 'length' => 128, 'default' => ''],
+];
+
+$GLOBALS['TL_DCA']['tl_form']['fields']['mailchimpOptIn'] = [
+    'inputType' => 'checkbox',
+    'eval' => ['tl_class' => 'w50 m12'],
+    'sql' => ['type' => 'boolean', 'default' => false],
+];
+
+PaletteManipulator::create()
+    ->addLegend('mailchimp_legend', null)
+    ->addField('enableMailchimp', 'mailchimp_legend', PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('default', 'tl_form')
+;
+
+$GLOBALS['TL_DCA']['tl_form']['palettes']['__selector__'][] = 'enableMailchimp';
+$GLOBALS['TL_DCA']['tl_form']['subpalettes']['enableMailchimp'] = 'mailchimpList,mailchimpGroups,mailchimpConfirmField,mailchimpOptIn,mailchimpMergeTags';

--- a/src/Resources/contao/languages/de/default.php
+++ b/src/Resources/contao/languages/de/default.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['TL_LANG']['ERR']['mailchimpMergeTagsEmailMissing'] = 'Der "EMAIL" Merge-Tag fehlt.';

--- a/src/Resources/contao/languages/de/tl_form.php
+++ b/src/Resources/contao/languages/de/tl_form.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['TL_LANG']['tl_form']['mailchimp_legend'] = 'Mailchimp';
+$GLOBALS['TL_LANG']['tl_form']['enableMailchimp'] = ['Mailchimp aktivieren', 'Aktiviert Mailchimp Abonnements für dieses Formular.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpList'] = ['Mailchimp Liste', 'Die Mailchimp Liste für die Abonnements.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpGroups'] = ['Interessensgruppen', 'Die optionalen Interessensgruppen für die Abonnements.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpMergeTags'] = ['Merge-Tags', 'Die Merge-Tag Definitonen für dieses Formular. Der "Schlüssel" ist der Merge-Tag, der "Wert" ist der Name des Formularfelds, welches dann den Wert enthält.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpConfirmField'] = ['Bestätigungsfeld', 'Definiert ein optionales Bestätigungsfeld, welches ausgewählt sein muss, damit ein Abonnement erzeugt wird.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpOptIn'] = ['Double Opt-in verwenden', 'Double Opt-in für die Abonnements verwenden.'];

--- a/src/Resources/contao/languages/en/default.php
+++ b/src/Resources/contao/languages/en/default.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['TL_LANG']['ERR']['mailchimpMergeTagsEmailMissing'] = 'The "EMAIL" merge tag is missing.';

--- a/src/Resources/contao/languages/en/tl_form.php
+++ b/src/Resources/contao/languages/en/tl_form.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['TL_LANG']['tl_form']['mailchimp_legend'] = 'Mailchimp';
+$GLOBALS['TL_LANG']['tl_form']['enableMailchimp'] = ['Enable Mailchimp', 'Enables Mailchimp subscriptions for this form.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpList'] = ['Mailchimp list', 'Select the Mailchimp list to subscribe to.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpGroups'] = ['Interest groups', 'Select optional interest groups to subscribe to.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpMergeTags'] = ['Merge tags', 'Define the merge tags for this form. The "Key" is the merge tag while the "Value" is the form field holding the value.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpConfirmField'] = ['Confirm field', 'Set an optional form field that is required to be set in order to initiate the subscription process.'];
+$GLOBALS['TL_LANG']['tl_form']['mailchimpOptIn'] = ['Use double opt-in', 'Use double opt-in for the subscription.'];


### PR DESCRIPTION
Often times our customers also want to enable the possibility to subscribe to a Mailchimp newsletter in regular Contao forms. i.e. the form is collecting other data (possibly stored with `terminal42/contao-leads` for example) but then the email address should also be subscribed to a Mailchimp newsletter (may be when clicking a checkbox).

So far we have implemented our own `processFormData` listeners in these projects, but since we need it in yet another project now, I thought it would be good to have this integrated directly into this extension :)

**Usage:**

1. Set up the Mailchimp API credentials first as usual.
2.  Enable in the form's settings.
3. Select a Mailchimp list.
4. Optionally activate interest groups. Every subscription will have these interest groups enabled.
5. Optionally set a confirm form field's name. The subscription will only be done, if the value of that form field is not empty.
6. Optionally enable Mailchimp double opt-in.
7. Define the merge tags. The "Key" is the Mailchimp merge tag while the "Value" is the form field's name. You need at least the `EMAIL` merge tag in order to indicate which form field holds the email address. Also the Mailchimp API requires at least the `EMAIL` merge tag.

<img src="https://user-images.githubusercontent.com/4970961/141818946-0a8aa7fd-c771-49b0-9487-4d7c43e87d1e.png" width="640">


**Notes:**

- I have put the whole functionality into a single service, i.e. this one service implements all the necessary callbacks/hooks. This way everything is self contained. But I can split it up if preferred.
- I used PHP language files since they are much easier to manage (if not using external translator tools), I hope you don't mind 😁 
- `oneup/mailchimp-api-v3` currently does not provide much error information when subscribing. So the logging can only log whether it was successful or not - without access to the reason when not successful.
- PR is a draft for now as we are still testing this in a live instance.