### PR TITLE
Fix "Undefined property" warning

### DIFF
--- a/src/Module/ModuleSubscribe.php
+++ b/src/Module/ModuleSubscribe.php
@@ -99,7 +99,7 @@ class ModuleSubscribe extends Module
         }
 
         // sort groups by displayOrder ASC
-        usort($groups, fn ($a, $b) => ($a->displayOrder > $b->displayOrder) ? 1 : -1);
+        usort($groups, fn ($a, $b) => (($a->displayOrder ?? 0) > ($b->displayOrder ?? 0)) ? 1 : -1);
 
         $interestCategoryIds = [];
 


### PR DESCRIPTION
Fixes the following warning:

```
ErrorException:
Warning: Undefined property: stdClass::$displayOrder

  at vendor\oneup\contao-mailchimp\src\Module\ModuleSubscribe.php:102
```